### PR TITLE
Fix Dockerfile for repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:18
 WORKDIR /app
-COPY package*.json ./
-RUN npm install  # ✅ Install dependencies at build time
+
+# Copy the entire repository. The project currently does not rely on a
+# Node.js package manifest so we skip installing npm dependencies.
 COPY . .
-CMD ["npm", "start"]  # ✅ Single CMD for runtime
+
+# Ensure our start script is executable and run it by default.
+RUN chmod +x runpod-start.sh
+
+CMD ["./runpod-start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# vanity-addy-generator
+# Vanity Address Generator
+
+This repository contains GPU-based tools for generating vanity addresses.
+
+## Building the Docker Image
+
+Use the provided script to build the Docker image. The script takes an optional tag name (defaults to `vanity-addy:latest`).
+
+```bash
+./scripts/build-docker.sh [custom-tag]
+```
+
+The resulting image runs `runpod-start.sh` on container startup.
+

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+TAG=${1:-vanity-addy:latest}
+# Build the Docker image from the repository root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+docker build -t "$TAG" .
+


### PR DESCRIPTION
## Summary
- sync Dockerfile with current repo by removing dependency on missing package manifests
- use runpod-start.sh as entrypoint
- add helper script and docs to build Docker image

## Testing
- `docker build -t vanity-addy-test .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68633db0eab08327920c0d44deb78709