### PR TITLE
Fix wipe API handler

### DIFF
--- a/app/api/compliance/wipe.ts
+++ b/app/api/compliance/wipe.ts
@@ -1,13 +1,40 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { initiateWipe } from "@/lib/wipe-utils"; 
+import { NextApiRequest, NextApiResponse } from 'next';
+import jwt from 'jsonwebtoken';
+import { initiateWipe } from '@/lib/wipe-utils';
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === 'DELETE') {
-    // Verify JWT and initiate wipe
-    const { txSignature } = await 
-    (req.body.userId);
-    res.status(202).json({ txSignature });
+  if (req.method !== 'DELETE') {
+    res.setHeader('Allow', 'DELETE');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const authHeader = req.headers['authorization'] || '';
+  const token = Array.isArray(authHeader)
+    ? authHeader[0]
+    : authHeader.replace(/^Bearer\s+/i, '');
+
+  if (!token) {
+    return res.status(401).json({ error: 'Missing token' });
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET || 'secret';
+    const payload = jwt.verify(token, secret) as { userId?: string };
+
+    const userId = payload.userId || req.body?.userId;
+
+    if (!userId) {
+      return res.status(400).json({ error: 'Missing userId' });
+    }
+
+    const { txSignature } = await initiateWipe(userId);
+    return res.status(202).json({ txSignature });
+  } catch (err) {
+    console.error(err);
+    return res.status(401).json({ error: 'Invalid token' });
   }
 }
+

--- a/app/lib/wipe-utils.ts
+++ b/app/lib/wipe-utils.ts
@@ -1,5 +1,8 @@
 // Basic implementation - adjust as needed
-export function initiateWipe() {
-    console.log("Wipe initiated");
-    // Add actual wipe logic here
-  }
+export async function initiateWipe(userId: string) {
+  console.log(`Wipe initiated for ${userId}`);
+  // TODO: add actual wipe logic here
+  return {
+    txSignature: "dummy-signature"
+  };
+}


### PR DESCRIPTION
## Summary
- implement wipe handler logic with JWT validation
- update `initiateWipe` to accept a user ID and return a placeholder signature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68633efc31148327bb45b32df66e6700