### PR TITLE
Add simple Next.js UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains a simplified prototype used to experiment with generati
 - `scripts` – Helper scripts including `build-docker.sh` used to build the Docker image.
 - `runpod-start.sh` – Entry point executed inside the container. It configures the GPU and launches the vanity address generator binary.
 - `Dockerfile` – Builds a Node based image and runs `runpod-start.sh` by default.
+- `src` – Minimal Next.js app containing the `Home` component and related UI logic.
 
 ## Prerequisites
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface ProgressBarProps {
+  progress: number; // value between 0 and 1
+}
+
+export default function ProgressBar({ progress }: ProgressBarProps) {
+  const pct = Math.min(1, Math.max(0, progress)) * 100;
+  return (
+    <div style={{ border: '1px solid #ccc', width: '100%', padding: 2 }}>
+      <div
+        style={{
+          height: 10,
+          width: `${pct}%`,
+          backgroundColor: 'green'
+        }}
+      />
+    </div>
+  );
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,13 @@
+export type Tier = 'basic' | 'pro' | 'enterprise';
+
+const tierMultiplier: Record<Tier, number> = {
+  basic: 1,
+  pro: 2,
+  enterprise: 3
+};
+
+export function calculatePrice(pattern: string, tier: Tier): number {
+  const len = pattern.length;
+  const multiplier = tierMultiplier[tier] ?? 1;
+  return len * multiplier;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import ProgressBar from '../components/ProgressBar';
+import { calculatePrice, Tier } from '../lib/pricing';
+
+export default function Home() {
+  const [pattern, setPattern] = useState('');
+  const [tier, setTier] = useState<Tier>('basic');
+  const [progress, setProgress] = useState(0);
+
+  const price = calculatePrice(pattern, tier);
+
+  // Simple fake progress update when pattern or tier changes
+  React.useEffect(() => {
+    setProgress(0);
+    const id = setInterval(() => {
+      setProgress((p) => {
+        const next = p + 0.1;
+        return next > 1 ? 1 : next;
+      });
+    }, 200);
+    return () => clearInterval(id);
+  }, [pattern, tier]);
+
+  return (
+    <div style={{ maxWidth: 400, margin: '0 auto' }}>
+      <h1>Vanity Address Generator</h1>
+      <label>
+        Pattern:
+        <input
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          style={{ width: '100%' }}
+        />
+      </label>
+      <label>
+        Tier:
+        <select value={tier} onChange={(e) => setTier(e.target.value as Tier)}>
+          <option value="basic">Basic</option>
+          <option value="pro">Pro</option>
+          <option value="enterprise">Enterprise</option>
+        </select>
+      </label>
+      <p>Price: ${price.toFixed(2)}</p>
+      <ProgressBar progress={progress} />
+    </div>
+  );
+}

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,0 +1,9 @@
+import { calculatePrice } from '../src/lib/pricing';
+
+describe('calculatePrice', () => {
+  it('calculates price based on pattern length and tier', () => {
+    expect(calculatePrice('abc', 'basic')).toBe(3);
+    expect(calculatePrice('abc', 'pro')).toBe(6);
+    expect(calculatePrice('abc', 'enterprise')).toBe(9);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["app/**/*.ts", "tests/**/*.ts"]
+  "include": ["app/**/*.ts", "src/**/*", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add minimal Next.js style `src` directory with `Home` component
- implement price calculator and progress bar modules
- update tsconfig and docs
- add unit test for pricing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863550cc6008327809f08c68a5a28cc