### PR TITLE
Add monitor script and stub CUDA binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY . .
 
 # Ensure our start script is executable and run it by default.
-RUN chmod +x runpod-start.sh
+RUN chmod +x runpod-start.sh \
+    && chmod +x src/cuda/vanity
 
 CMD ["./runpod-start.sh"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repository contains a simplified prototype used to experiment with generati
    docker run --gpus all vanity-addy:latest
    ```
 
-   When the container starts it executes `runpod-start.sh` which configures the NVIDIA driver, launches a monitoring script and finally starts the GPU based `vanity` binary located at `/app/src/cuda/vanity`.
+  When the container starts it executes `runpod-start.sh` which configures the NVIDIA driver, launches a monitoring script located at `/app/controller/monitor.py` and finally starts the GPU based `vanity` binary located at `/app/src/cuda/vanity`.
 
 ## How it fits together
 

--- a/controller/monitor.py
+++ b/controller/monitor.py
@@ -1,0 +1,29 @@
+import subprocess
+import time
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+
+INTERVAL = 30  # seconds
+
+def log_gpu_stats():
+    try:
+        out = subprocess.check_output([
+            "nvidia-smi",
+            "--query-gpu=utilization.gpu,temperature.gpu,memory.used,memory.total",
+            "--format=csv,noheader,nounits",
+        ])
+        logging.info("GPU Stats: %s", out.decode().strip())
+    except Exception as exc:
+        logging.error("Failed to read GPU stats: %s", exc)
+
+
+def main():
+    logging.info("Starting GPU monitor")
+    while True:
+        log_gpu_stats()
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cuda/vanity
+++ b/src/cuda/vanity
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Placeholder for CUDA vanity address generator
+# In a real implementation this would execute a compiled GPU binary.
+echo "Starting placeholder vanity generator with args: $@"
+# Simulate work
+sleep 5


### PR DESCRIPTION
## Summary
- add missing `monitor.py` under `controller` to log GPU stats
- include placeholder CUDA binary at `src/cuda/vanity`
- update Dockerfile to mark new binary as executable
- document monitor script location in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686357b0906c8327bf696fd6efafde27