### PR TITLE
Add Diesel connection and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ This repository contains a simplified prototype used to experiment with generati
 
    When the container starts it executes `runpod-start.sh` which configures the NVIDIA driver, launches a monitoring script and finally starts the GPU based `vanity` binary located at `/app/src/cuda/vanity`.
 
+## Database configuration
+
+Diesel helpers such as `run_migrations` expect a PostgreSQL connection string.
+Set the `DATABASE_URL` environment variable or add a `.env` file containing:
+
+```
+DATABASE_URL=postgres://user:password@localhost/dbname
+```
+
 ## How it fits together
 
 - The **Rust program** in `app/programs/src` defines the on-chain instruction `store_wipe_proof`.  It serializes a `WipeProof` struct to the beginning of a Solana account so that a record of the wipe can be stored permanently.

--- a/app/programs/src/Cargo.toml
+++ b/app/programs/src/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 anchor-lang = "0.30.0"
 borsh = "0.10.3"
+diesel = { version = "2.1.0", features = ["postgres"] }
+diesel_migrations = "2.1.0"
+dotenvy = "0.15"
+

--- a/app/programs/src/bin/run_migrations.rs
+++ b/app/programs/src/bin/run_migrations.rs
@@ -1,5 +1,6 @@
 // programs/revenue-split/src/bin/run_migrations.rs
 use diesel_migrations::{embed_migrations, MigrationHarness};
+use vanity_addy::establish_connection;
 use std::error::Error;
 
 pub fn run() -> Result<(), Box<dyn Error>> {

--- a/app/programs/src/src/db.rs
+++ b/app/programs/src/src/db.rs
@@ -1,0 +1,14 @@
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use dotenvy::dotenv;
+use std::env;
+
+pub fn establish_connection() -> PgConnection {
+    dotenv().ok();
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+}
+
+

--- a/app/programs/src/src/lib.rs
+++ b/app/programs/src/src/lib.rs
@@ -4,6 +4,9 @@ use anchor_lang::prelude::*;
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkgE9DuAyY29S");
 
 pub mod wipe;
+pub mod db;
+
+pub use db::establish_connection;
 
 pub use wipe::*;
 


### PR DESCRIPTION
## Summary
- hook up Diesel with a helper to establish a database connection
- expose the connection utility from the library crate
- use the helper in the migration runner
- document required `DATABASE_URL` variable

## Testing
- `npm test`
- `cargo check --manifest-path app/programs/src/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6863618977108327ba934262e28fb04f