### PR TITLE
Implement missing scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repository contains a simplified prototype used to experiment with generati
    docker run --gpus all vanity-addy:latest
    ```
 
-  When the container starts it executes `runpod-start.sh` which configures the NVIDIA driver, launches a monitoring script located at `/app/controller/monitor.py` and finally starts the GPU based `vanity` binary located at `/app/src/cuda/vanity`.
+When the container starts it executes `runpod-start.sh` which configures the NVIDIA driver, launches a monitoring script located at `/app/controller/monitor.py` and finally starts the GPU based `vanity` binary located at `/app/src/cuda/vanity`.
 
 ## Database configuration
 
@@ -69,6 +69,20 @@ Set the `DATABASE_URL` environment variable or add a `.env` file containing:
 
 ```
 DATABASE_URL=postgres://user:password@localhost/dbname
+```
+
+## Helper scripts
+
+The `scripts` directory contains additional helper utilities:
+
+- `deploy.sh` – deploys the Solana program using the Anchor CLI.
+- `monitor-cost.sh` – runs the GPU monitoring tool located in `controller/monitor.py`.
+
+Run them with:
+
+```bash
+./scripts/deploy.sh        # deploy the program
+./scripts/monitor-cost.sh  # start GPU usage logging
 ```
 
 ## How it fits together

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Deploy the on-chain program using Anchor
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+PROGRAM_DIR="$ROOT_DIR/app/programs"
+
+if ! command -v anchor >/dev/null; then
+  echo "anchor CLI not found. Please install Anchor before deploying." >&2
+  exit 1
+fi
+
+cd "$PROGRAM_DIR"
+anchor deploy

--- a/scripts/monitor-cost.sh
+++ b/scripts/monitor-cost.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Start the GPU monitoring helper
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+python3 "$ROOT_DIR/controller/monitor.py"


### PR DESCRIPTION
## Summary
- add deploy script using Anchor CLI
- add monitor-cost script to run GPU monitor
- remove leftover configs/audit file
- document helper scripts in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636ceac55c8327865ec90861566841