### PR TITLE
Install dependencies during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM node:18
 WORKDIR /app
 
-# Copy the entire repository. The project currently does not rely on a
-# Node.js package manifest so we skip installing npm dependencies.
+# Copy package manifests first to leverage Docker layer caching and install
+# dependencies.  This project now includes a `package.json` so we install the
+# required Node modules before copying the rest of the repository.
+COPY package*.json ./
+RUN npm ci
+
+# Copy the remainder of the repository
 COPY . .
 
-# Ensure our start script is executable and run it by default.
+# Ensure our start script and GPU binary are executable and run the start script
+# by default.
 RUN chmod +x runpod-start.sh \
     && chmod +x src/cuda/vanity
 


### PR DESCRIPTION
## Summary
- install Node dependencies in the Docker image
- keep runpod-start.sh as the container entrypoint

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686375f7ec448327b27f6435778903a0