### PR TITLE
Implement wallet context and backend skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+REDIS_URL=redis://localhost:6379/0
+NEXT_PUBLIC_SOLANA_RPC=https://api.devnet.solana.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ This repository contains a simplified prototype used to experiment with generati
 - The **Docker setup** packages these pieces together and provides an environment capable of running GPU code.  Building the image copies the repository contents and marks `runpod-start.sh` as the container entry point.  This entry point configures the GPU and executes the external CUDA based vanity address generator alongside the Node utilities.
 
 This repository serves as a minimal demonstration of how Rust on-chain programs, Node.js helpers and a Docker based GPU workflow can be combined for compliance oriented address generation tasks.
+
+## Backend API (FastAPI)
+
+A simple FastAPI application is located in `backend`. Run it with `uvicorn backend.main:app` after setting the `REDIS_URL` environment variable. The `/api/vanity/submit` endpoint enqueues a job and `/api/vanity/status/{id}` reports progress.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .submit import router as submit_router
+from .status import router as status_router
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+app.include_router(submit_router, prefix='/api')
+app.include_router(status_router, prefix='/api')

--- a/backend/redis_client.py
+++ b/backend/redis_client.py
@@ -1,0 +1,11 @@
+import os
+import redis
+
+_redis = None
+
+def get_redis() -> redis.Redis:
+    global _redis
+    if _redis is None:
+        url = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+        _redis = redis.Redis.from_url(url)
+    return _redis

--- a/backend/status.py
+++ b/backend/status.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, HTTPException
+from .redis_client import get_redis
+
+router = APIRouter()
+
+@router.get('/vanity/status/{job_id}')
+def status(job_id: str):
+    r = get_redis()
+    if not r.exists(job_id):
+        raise HTTPException(status_code=404, detail='Job not found')
+    return {k.decode(): v.decode() for k, v in r.hgetall(job_id).items()}

--- a/backend/submit.py
+++ b/backend/submit.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+import uuid
+from .redis_client import get_redis
+
+router = APIRouter()
+
+class SubmitRequest(BaseModel):
+    pattern: str
+    tier: str
+    address: str
+
+@router.post('/vanity/submit')
+def submit(req: SubmitRequest):
+    job_id = str(uuid.uuid4())
+    r = get_redis()
+    r.hset(job_id, mapping={'status': 'queued'})
+    return {'job_id': job_id}

--- a/src/components/WalletProvider.tsx
+++ b/src/components/WalletProvider.tsx
@@ -1,0 +1,43 @@
+'use client';
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface WalletContextValue {
+  publicKey: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextValue | undefined>(undefined);
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+
+  async function connect() {
+    const provider = (window as any)?.solana;
+    if (provider?.connect) {
+      const res = await provider.connect();
+      const key = res?.publicKey?.toString() ?? null;
+      setPublicKey(key);
+    }
+  }
+
+  function disconnect() {
+    const provider = (window as any)?.solana;
+    if (provider?.disconnect) {
+      provider.disconnect();
+    }
+    setPublicKey(null);
+  }
+
+  return (
+    <WalletContext.Provider value={{ publicKey, connect, disconnect }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet() {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error('useWallet must be used within WalletProvider');
+  return ctx;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,19 @@
+export async function submitVanity(pattern: string, tier: string, address: string) {
+  const res = await fetch('/api/vanity/submit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pattern, tier, address })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to submit job');
+  }
+  return res.json();
+}
+
+export async function getStatus(jobId: string) {
+  const res = await fetch(`/api/vanity/status/${jobId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch status');
+  }
+  return res.json();
+}

--- a/src/lib/connect.ts
+++ b/src/lib/connect.ts
@@ -1,0 +1,11 @@
+import { Connection, clusterApiUrl } from '@solana/web3.js';
+
+let connection: Connection | null = null;
+
+export function getConnection(): Connection {
+  if (!connection) {
+    const endpoint = process.env.NEXT_PUBLIC_SOLANA_RPC || clusterApiUrl('devnet');
+    connection = new Connection(endpoint);
+  }
+  return connection;
+}


### PR DESCRIPTION
## Summary
- add a basic WalletProvider for connecting to browser wallets
- support retrieving a Solana connection with `getConnection`
- add simple API bindings for vanity requests
- implement FastAPI backend with Redis client and job endpoints
- document backend usage in README
- ignore `.env` files and provide `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686337d3abd483279afe545c7331a481