### PR TITLE
Add TierSelector component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@project-serum/anchor": "^0.26.0",
         "@solana/web3.js": "^1.98.2",
+        "jsonwebtoken": "^9.0.2",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "jest": "^30.0.3",
         "ts-jest": "^29.4.0",
         "typescript": "^5.8.3"
@@ -1889,6 +1891,24 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
@@ -2564,6 +2584,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2992,6 +3018,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4385,6 +4420,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4415,11 +4505,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lower-case": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "jest": "^30.0.3",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"
@@ -22,6 +23,7 @@
   "dependencies": {
     "@project-serum/anchor": "^0.26.0",
     "@solana/web3.js": "^1.98.2",
+    "jsonwebtoken": "^9.0.2",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,12 @@
 
 import React, { useState } from 'react';
 import ProgressBar from '../components/ProgressBar';
+import TierSelector from '../components/TierSelector';
 import { calculatePrice, Tier } from '../lib/pricing';
-
-const tiers: Tier[] = ['basic', 'standard', 'premium'];
 
 export default function Home() {
   const [pattern, setPattern] = useState('');
-  const [tier, setTier] = useState<Tier>('basic');
+  const [tier, setTier] = useState<Tier>('standard');
   const [progress, setProgress] = useState(0);
 
   const price = calculatePrice(pattern, tier);
@@ -38,22 +37,7 @@ export default function Home() {
           />
         </label>
       </div>
-      <div style={{ marginTop: 12 }}>
-        <label>
-          Tier:
-          <select
-            value={tier}
-            onChange={(e) => setTier(e.target.value as Tier)}
-            style={{ marginLeft: 8 }}
-          >
-            {tiers.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
+      <TierSelector tier={tier} setTier={setTier} />
       <div style={{ marginTop: 12 }}>Price: ${price.toFixed(2)}</div>
       <button style={{ marginTop: 12 }} onClick={handleSearch}>
         Start Search

--- a/src/components/TierSelector.tsx
+++ b/src/components/TierSelector.tsx
@@ -1,0 +1,28 @@
+'use client';
+import React from 'react';
+
+export default function TierSelector({ tier, setTier }: { tier: string; setTier: (t: string) => void }) {
+  return (
+    <div className="mb-4">
+      <label className="block mb-2">Speed Tier</label>
+      <div className="flex gap-2">
+        {['standard', 'priority', 'turbo'].map((t) => (
+          <button
+            key={t}
+            onClick={() => setTier(t)}
+            className={`p-2 border rounded flex-1 ${tier === t ? 'bg-blue-100 border-blue-500' : ''}`}
+          >
+            <div className="font-bold">{t.charAt(0).toUpperCase() + t.slice(1)}</div>
+            <div className="text-xs">
+              {t === 'standard'
+                ? '5-60 min'
+                : t === 'priority'
+                ? '1-5 min (+0.05 SOL)'
+                : '<10 sec (+0.15 SOL)'}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,12 +1,12 @@
-export type Tier = 'basic' | 'standard' | 'premium';
+export type Tier = 'standard' | 'priority' | 'turbo';
 
-const multipliers: Record<Tier, number> = {
-  basic: 1,
-  standard: 2,
-  premium: 3,
+const extras: Record<Tier, number> = {
+  standard: 0,
+  priority: 0.05,
+  turbo: 0.15,
 };
 
 export function calculatePrice(pattern: string, tier: Tier): number {
   const base = pattern.length * 10;
-  return base * multipliers[tier];
+  return base + extras[tier];
 }


### PR DESCRIPTION
## Summary
- add `TierSelector` client component for speed selection
- update pricing logic to use standard/priority/turbo tiers
- expose tier selector in the home page
- install `jsonwebtoken` runtime dependency with types

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68633ca4b9dc83278692b9f73fe59783