### PR TITLE
Add layout wrapper for Next.js app

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import '../styles/globals.css';
+import { Inter } from 'next/font/google';
+import { WalletProvider } from '../components/WalletProvider';
+import React, { ReactNode } from 'react';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata = {
+  title: 'Vanity Address Generator',
+  description: 'Search for custom Solana addresses'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <WalletProvider>{children}</WalletProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}


### PR DESCRIPTION
## Summary
- wrap app content with global layout
- include global styles and Google font
- mount WalletProvider in layout

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a7fc401c8327a8056ccfe293668a