### PR TITLE
Add neon theme styling and live info panel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,71 @@
+body {
+  background: #0d1117;
+  color: #c9d1d9;
+  font-family: sans-serif;
+}
+
+.gradient-text {
+  background: linear-gradient(90deg, #ff00cc, #3333ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.glow-btn {
+  background: #111;
+  border: 1px solid #0ff;
+  color: #0ff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  box-shadow: 0 0 8px #0ff;
+  transition: box-shadow 0.3s;
+}
+.glow-btn:hover {
+  box-shadow: 0 0 16px #0ff;
+}
+
+.card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.1);
+}
+
+.progress-container {
+  width: 100%;
+  background: #30363d;
+  height: 10px;
+  border-radius: 5px;
+  overflow: hidden;
+}
+.progress-fill {
+  background: linear-gradient(90deg, #0ff, #f0f);
+  height: 100%;
+  transition: width 0.3s;
+}
+
+.tier-selector {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.tier-button {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #111;
+  color: #0ff;
+  cursor: pointer;
+}
+.tier-button.active {
+  background: #0ff;
+  color: #111;
+}
+
+.font-bold {
+  font-weight: bold;
+}
+.text-xs {
+  font-size: 12px;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './globals.css';
+
+export const metadata = {
+  title: 'Vanity Address Generator',
+  description: 'Generate Solana vanity addresses',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,21 +3,30 @@
 import React, { useState } from 'react';
 import ProgressBar from '../components/ProgressBar';
 import TierSelector from '../components/TierSelector';
+import LiveInfoPanel from '../components/LiveInfoPanel';
 import { calculatePrice, Tier } from '../lib/pricing';
 
 export default function Home() {
   const [pattern, setPattern] = useState('');
   const [tier, setTier] = useState<Tier>('standard');
   const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState('Idle');
+  const [total, setTotal] = useState(0);
 
   const price = calculatePrice(pattern, tier);
 
   function handleSearch() {
     setProgress(0);
+    setTotal(0);
+    setStatus('Searching...');
     const interval = setInterval(() => {
       setProgress((p) => {
         const next = Math.min(p + 0.1, 1);
-        if (next === 1) clearInterval(interval);
+        setTotal((t) => t + 100);
+        if (next === 1) {
+          clearInterval(interval);
+          setStatus('Complete');
+        }
         return next;
       });
     }, 300);
@@ -25,8 +34,8 @@ export default function Home() {
 
   return (
     <main style={{ padding: 20 }}>
-      <h1>Vanity Address Generator</h1>
-      <div>
+      <h1 className="gradient-text">Vanity Address Generator</h1>
+      <div className="card" style={{ marginTop: 20 }}>
         <label>
           Pattern:
           <input
@@ -36,14 +45,24 @@ export default function Home() {
             style={{ marginLeft: 8 }}
           />
         </label>
+        <TierSelector tier={tier} setTier={setTier} />
+        <div style={{ marginTop: 12 }}>Price: ${price.toFixed(2)}</div>
+        <button className="glow-btn" style={{ marginTop: 12 }} onClick={handleSearch}>
+          Start Search
+        </button>
+        <div style={{ marginTop: 20 }}>
+          <ProgressBar progress={progress} />
+        </div>
       </div>
-      <TierSelector tier={tier} setTier={setTier} />
-      <div style={{ marginTop: 12 }}>Price: ${price.toFixed(2)}</div>
-      <button style={{ marginTop: 12 }} onClick={handleSearch}>
-        Start Search
-      </button>
       <div style={{ marginTop: 20 }}>
-        <ProgressBar progress={progress} />
+        <LiveInfoPanel
+          difficulty={pattern.length.toString()}
+          total={total}
+          eta={status === 'Complete' ? '0s' : `${Math.round((1 - progress) * 10)}s`}
+          speed={`${(total / (progress || 1)).toFixed(0)}/s`}
+          status={status}
+          progress={progress}
+        />
       </div>
     </main>
   );

--- a/src/components/LiveInfoPanel.tsx
+++ b/src/components/LiveInfoPanel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ProgressBar from './ProgressBar';
+
+export interface LiveInfoPanelProps {
+  difficulty: string;
+  total: number;
+  eta: string;
+  speed: string;
+  status: string;
+  progress: number;
+}
+
+export default function LiveInfoPanel({
+  difficulty,
+  total,
+  eta,
+  speed,
+  status,
+  progress,
+}: LiveInfoPanelProps) {
+  return (
+    <div className="card">
+      <div>Difficulty: {difficulty}</div>
+      <div>Total Generated: {total}</div>
+      <div>Estimated Time: {eta}</div>
+      <div>Speed: {speed}</div>
+      <div>Status: {status}</div>
+      <ProgressBar progress={progress} />
+    </div>
+  );
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -7,8 +7,8 @@ interface ProgressBarProps {
 export default function ProgressBar({ progress }: ProgressBarProps) {
   const width = Math.min(Math.max(progress, 0), 1) * 100;
   return (
-    <div style={{ width: '100%', background: '#e0e0e0', height: 10 }}>
-      <div style={{ width: `${width}%`, background: '#0070f3', height: '100%' }} />
+    <div className="progress-container">
+      <div className="progress-fill" style={{ width: `${width}%` }} />
     </div>
   );
 }

--- a/src/components/TierSelector.tsx
+++ b/src/components/TierSelector.tsx
@@ -5,12 +5,12 @@ export default function TierSelector({ tier, setTier }: { tier: string; setTier:
   return (
     <div className="mb-4">
       <label className="block mb-2">Speed Tier</label>
-      <div className="flex gap-2">
+      <div className="tier-selector">
         {['standard', 'priority', 'turbo'].map((t) => (
           <button
             key={t}
             onClick={() => setTier(t)}
-            className={`p-2 border rounded flex-1 ${tier === t ? 'bg-blue-100 border-blue-500' : ''}`}
+            className={`tier-button ${tier === t ? 'active' : ''}`}
           >
             <div className="font-bold">{t.charAt(0).toUpperCase() + t.slice(1)}</div>
             <div className="text-xs">


### PR DESCRIPTION
## Summary
- add global styles for neon cards, glowing buttons and progress bars
- set up app layout importing global CSS
- implement `LiveInfoPanel` component with progress bar
- update `ProgressBar` and `TierSelector` to use new styles
- integrate info panel and apply neon styling in home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc37d0e8832798b18e87cda5727d