### PR TITLE
Add Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository contains a simplified prototype used to experiment with generati
 - **Node.js** 18 or newer and `npm` for running the tests and API scripts.
 - **Rust** toolchain (stable) for building the on-chain program located in `app/programs/src`.
 - **Docker** for packaging and running the GPU based generator.
+- **Python** 3.11 or newer for the FastAPI backend. Install dependencies from `backend/requirements.txt`.
 
 ## Building and running
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+redis==5.0.1


### PR DESCRIPTION
## Summary
- define FastAPI backend dependencies in `backend/requirements.txt`
- document Python requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863c22426a48327a66958ac776e835b