### PR TITLE
Remove leftover merge markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ target/
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
-=======
-node_modules/
-.env

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 This repository contains scripts for launching a GPU-based vanity address generator.
 The `runpod-start.sh` script initializes GPU settings, starts a monitoring process,
 and runs the generator located in `src/cuda/vanity`.
-=======
--codebase-section
-# vanity-addy-generator
-
-This repository will contain tools for generating vanity cryptocurrency addresses.
-# Vanity Addy Generator
 
 This repository contains a simplified prototype used to experiment with generating vanity cryptocurrency addresses while storing compliance information on the Solana blockchain.  The project is split across a small Rust program and several Node.js utilities and is intended to be run inside a Docker container.
 
@@ -103,6 +97,4 @@ This repository serves as a minimal demonstration of how Rust on-chain programs,
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-=======
-This repository serves as a minimal demonstration of how Rust on-chain programs, Node.js helpers and a Docker based GPU workflow can be combined for compliance oriented address generation tasks mainmain
 

--- a/runpod-start.sh
+++ b/runpod-start.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-
-nvidia-smi -pm 1 || true
-nvidia-smi -ac 5001,1410 || true
-python app/controller/monitor.py &
-./app/src/cuda/vanity --gpus 2
-=======
 set -e
 
 if command -v nvidia-smi >/dev/null 2>&1; then
@@ -16,4 +10,3 @@ fi
 
 python controller/monitor.py &
 exec ./src/cuda/vanity --gpus 2
-

--- a/src/cuda/vanity
+++ b/src/cuda/vanity
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 import argparse
 import time
@@ -17,10 +16,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-=======
-#!/bin/bash
-# Placeholder for CUDA vanity address generator
-# In a real implementation this would execute a compiled GPU binary.
-echo "Starting placeholder vanity generator with args: $@"
-# Simulate work
-sleep 5


### PR DESCRIPTION
## Summary
- clean conflict markers from README, runpod-start.sh, `.gitignore` and vanity stub
- keep a single start script using controller/monitor.py

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b72650b4832783814b4ad631a7cc