### PR TITLE
Clean up Python CUDA helper

### DIFF
--- a/src/cuda/vanity
+++ b/src/cuda/vanity
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 import argparse
 import time
@@ -17,10 +16,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-=======
-#!/bin/bash
-# Placeholder for CUDA vanity address generator
-# In a real implementation this would execute a compiled GPU binary.
-echo "Starting placeholder vanity generator with args: $@"
-# Simulate work
-sleep 5


### PR DESCRIPTION
## Summary
- remove leftover shell code from `src/cuda/vanity`
- ensure the Python helper starts directly with a shebang

## Testing
- `npm install`
- `npm test`
- `python3 -m py_compile src/cuda/vanity`


------
https://chatgpt.com/codex/tasks/task_e_6863b3639bdc8327bfdbd12c4ae3a2f9