### PR TITLE
Add loading spinner and FastAPI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ This repository contains a simplified prototype used to experiment with generati
    npm test
    ```
 
+   Set `NEXT_PUBLIC_BACKEND_URL` to the base URL of the FastAPI server when
+   running the frontend locally. By default the value is empty which causes the
+   application to request the API at the same origin.
+
 2. Install Python dependencies for the backend:
 
    ```bash

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,3 +69,20 @@ body {
 .text-xs {
   font-size: 12px;
 }
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #0ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,7 @@
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
+
 export async function submitVanity(pattern: string, tier: string, address: string) {
-  const res = await fetch('/api/vanity/submit', {
+  const res = await fetch(`${API_BASE}/api/vanity/submit`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ pattern, tier, address })
@@ -11,7 +13,7 @@ export async function submitVanity(pattern: string, tier: string, address: strin
 }
 
 export async function getStatus(jobId: string) {
-  const res = await fetch(`/api/vanity/status/${jobId}`);
+  const res = await fetch(`${API_BASE}/api/vanity/status/${jobId}`);
   if (!res.ok) {
     throw new Error('Failed to fetch status');
   }


### PR DESCRIPTION
## Summary
- hook frontend API helpers to real FastAPI backend
- show spinner while waiting for search job
- expose `NEXT_PUBLIC_BACKEND_URL` env var in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686453bc880c8327a05d0527b2a8114e