### PR TITLE
Keep package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,5 @@ target/
 /build/
 
 # Optional lock files
-package-lock.json
 pnpm-lock.yaml
 yarn.lock


### PR DESCRIPTION
## Summary
- keep the package-lock file under version control
- stop ignoring `package-lock.json`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864a34fdb848327b5a2cab702f8c377