### PR TITLE
Fix module import path

### DIFF
--- a/backend/grpc_client.py
+++ b/backend/grpc_client.py
@@ -1,4 +1,12 @@
 import grpc
+import os
+import sys
+
+# Add path to the generated gRPC modules located under apps/gpu-node
+grpc_module_path = os.path.join(os.path.dirname(__file__), "..", "apps", "gpu-node")
+if grpc_module_path not in sys.path:
+    sys.path.append(grpc_module_path)
+
 import wallet_pb2
 import wallet_pb2_grpc
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from grpc_client import generate_wallet_grpc
-from redis import redis_conn
+from .grpc_client import generate_wallet_grpc
+from . import redis as redis_conn
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- fix relative import for grpc client in backend
- point gRPC client to generated modules

## Testing
- `npm test`
- `uvicorn backend.main:app --port 8000` *(started then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686563512a0483279d0a9b650ded3e26