### PR TITLE
Add vanity submit feature

### DIFF
--- a/src/components/VanityGenerator.tsx
+++ b/src/components/VanityGenerator.tsx
@@ -1,16 +1,27 @@
 import { useState } from 'react';
 import { generateVanityKeypair, Keypair } from '../lib/solana';
+import { submitVanity } from '../lib/api';
 
 export default function VanityGenerator() {
   const [prefix, setPrefix] = useState('');
   const [keypair, setKeypair] = useState<Keypair | null>(null);
   const [loading, setLoading] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(null);
 
   const handleGenerate = async () => {
     setLoading(true);
     const kp = await generateVanityKeypair(prefix);
     setKeypair(kp);
     setLoading(false);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const data = await submitVanity(prefix, 'standard', keypair?.publicKey || '');
+      setJobId(data.jobId || data.job_id);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (
@@ -25,6 +36,8 @@ export default function VanityGenerator() {
       <button onClick={handleGenerate} disabled={loading || !prefix}>
         {loading ? 'Generating...' : 'Generate'}
       </button>
+      <button onClick={handleSubmit} disabled={!prefix}>Submit</button>
+      {jobId && <p>Job ID: {jobId}</p>}
       {keypair && (
         <pre>{keypair.publicKey}</pre>
       )}


### PR DESCRIPTION
## Summary
- import `submitVanity`
- add `jobId` state and `handleSubmit` function
- show `Submit` button with job id after requesting `/api/vanity/submit`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68656b5b38e08327b9536646154761c0